### PR TITLE
King moves

### DIFF
--- a/app/src/test/java/com/cyberbot/checkers/game/GridTest.java
+++ b/app/src/test/java/com/cyberbot/checkers/game/GridTest.java
@@ -119,7 +119,10 @@ class GridTest {
         Grid grid = new Grid(size, playerRows);
         GridEntry srcEntry = grid.getEntryByCoords(srcX, srcY);
         GridEntry dstEntry = grid.getEntryByCoords(dstX, dstY);
-        srcEntry.setPlayer(PlayerNum.FIRST);  // In order to not trigger InvalidArgumentException
+
+        // In order to not trigger InvalidArgumentException
+        srcEntry.setPlayer(PlayerNum.FIRST);
+        srcEntry.setPieceType(PieceType.ORDINARY);
 
         assertFalse(grid.destinationAllowed(srcEntry, dstEntry));
     }
@@ -131,7 +134,10 @@ class GridTest {
         Grid grid = new Grid(size, playerRows);
         GridEntry srcEntry = grid.getEntryByCoords(srcX, srcY);
         GridEntry dstEntry = grid.getEntryByCoords(dstX, dstY);
-        srcEntry.setPlayer(PlayerNum.FIRST);  // In order to not trigger InvalidArgumentException
+
+        // In order to not trigger InvalidArgumentException
+        srcEntry.setPlayer(PlayerNum.FIRST);
+        srcEntry.setPieceType(PieceType.ORDINARY);
 
         assertFalse(grid.destinationAllowed(srcEntry, dstEntry));
     }


### PR DESCRIPTION
In order to test this feature, make following temporary changes in `Grid.java`:

```java
// Comment out those lines in calculateKingMoves()
/*
if(entry.getPieceType() != PieceType.KING) {
    throw new IllegalArgumentException("Attempt to calculate king moves for non-king");
}
*/
```

```java
// Change this in getAllowedMoves()
if (entry.getPieceType() == PieceType.ORDINARY) {
    // allowedMoves = calculateOrdinaryPieceMoves(entry);
    allowedMoves = calculateKingMoves(entry);
}
```

Then you should be able to move your ordinary pieces as they were all kings.